### PR TITLE
Csv import refactor

### DIFF
--- a/app/components/flash_component.html.erb
+++ b/app/components/flash_component.html.erb
@@ -2,7 +2,6 @@
   <% if notice %>
       <p class="notice flex justify-between" data-controller="flash-component">
         <span><%= notice %></span>
-        <%# <span class="cursor-pointer" data-action="click->flash-component#closeFlash">X</span> %>
         <svg data-action="click->flash-component#closeFlash" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4 cursor-pointer">
           <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
         </svg>
@@ -10,12 +9,12 @@
   <% end %>
   <% if alert %>
     <% if alert[:invalid_records] %>
-      <% alert[:invalid_records].map do |record| %>
+      <% alert[:invalid_records].each do |ext_contract_id, errors| %>
         <div class="alert flex justify-between" data-controller="flash-component">
           <div>
-            <p>Contract with external_contract_id: <%= record.external_contract_id %> hasn't been created/updated due to errors:</p>
+            <p>Contract with external_contract_id: <%= ext_contract_id %> hasn't been created/updated due to errors:</p>
             <ul>
-              <% record.errors.full_messages.each do |message| %>
+              <% errors.each do |message| %>
                 <li><%= message %></li>
               <% end %>
             </ul>

--- a/app/controllers/contracts_controller.rb
+++ b/app/controllers/contracts_controller.rb
@@ -21,9 +21,7 @@ class ContractsController < ApplicationController
     begin
       return redirect_to request.referer, notice: 'No file added' if params[:file].nil?
       return redirect_to request.referer, notice: 'Only CSV files allowed' unless params[:file].content_type == 'text/csv'
-      # csv_array = csv_file_to_a
-      # CsvContractImportJob.perform_later(csv_array, session.id.to_s) #this job needs to be refactored into the CsvContractImportService class
-      CsvContractImportService.new(params[:file], session_id).call
+      CsvContractImportService.new(params[:file], session.id.to_s).call
       flash.now[:notice] = "The CSV import has begun and in process right now"
       respond_to do |format|
         format.turbo_stream
@@ -34,13 +32,4 @@ class ContractsController < ApplicationController
       render :index, status: :unprocessable_entity
     end
   end
-
-  # private
-  # this method needs to be refactored in the CsvContractImportService class
-  # def csv_file_to_a
-  #   require 'csv'
-  #   file = File.open(params[:file])
-  #   table = CSV.parse(file, headers: true)
-  #   table.to_a
-  # end
 end

--- a/app/controllers/contracts_controller.rb
+++ b/app/controllers/contracts_controller.rb
@@ -21,8 +21,9 @@ class ContractsController < ApplicationController
     begin
       return redirect_to request.referer, notice: 'No file added' if params[:file].nil?
       return redirect_to request.referer, notice: 'Only CSV files allowed' unless params[:file].content_type == 'text/csv'
-      csv_array = csv_file_to_a
-      CsvContractImportJob.perform_later(csv_array, session.id.to_s) #this job needs to be refactored into the CsvContractImportService class
+      # csv_array = csv_file_to_a
+      # CsvContractImportJob.perform_later(csv_array, session.id.to_s) #this job needs to be refactored into the CsvContractImportService class
+      CsvContractImportService.new(params[:file], session_id).call
       flash.now[:notice] = "The CSV import has begun and in process right now"
       respond_to do |format|
         format.turbo_stream
@@ -34,12 +35,12 @@ class ContractsController < ApplicationController
     end
   end
 
-  private
+  # private
   # this method needs to be refactored in the CsvContractImportService class
-  def csv_file_to_a
-    require 'csv'
-    file = File.open(params[:file])
-    table = CSV.parse(file, headers: true)
-    table.to_a
-  end
+  # def csv_file_to_a
+  #   require 'csv'
+  #   file = File.open(params[:file])
+  #   table = CSV.parse(file, headers: true)
+  #   table.to_a
+  # end
 end

--- a/app/jobs/csv_contract_import_job.rb
+++ b/app/jobs/csv_contract_import_job.rb
@@ -2,8 +2,111 @@ class CsvContractImportJob < ApplicationJob
   # include Sidekiq::Job
   queue_as :csv_import
 
-  def perform(csv_array, session_id)
-    import_service = CsvContractImportService.new(csv_array, session_id)
-    import_service.call
+  HEADERS = {
+    "Contract Owner" => 0,
+    "External Contract ID" => 1,
+    "Contract Name" => 2,
+    "Start Date" => 3,
+    "End Date" => 4,
+    "Contract Value" => 5,
+    "Supplier" => 6
+  }
+
+  def perform(csv_array:, session_id:, updated_contracts_counter: 0, invalid_contract_instances: {})
+    batch = csv_array.shift(500)
+    emails = get_unique_emails(batch)
+    owners = create_and_return_owners(emails)
+    recursive_values = upsert_contracts(owners, batch, session_id, updated_contracts_counter, invalid_contract_instances)
+    perform(csv_array:, session_id:, updated_contracts_counter: recursive_values[:counter], invalid_contract_instances: recursive_values[:invalid])
+  end
+
+  private
+
+  def get_unique_emails(batch)
+    batch.map {|row| row[HEADERS["Contract Owner"]]}.compact.uniq
+  end
+  
+  def create_and_return_owners(emails)
+    owners_hashes = emails.map do |email|
+      split_email = email.split(/\.|@/)
+      {
+        first_name: split_email[0].capitalize,
+        last_name: split_email[1].capitalize,
+        email: email
+      }
+    end
+
+    ContractOwner.upsert_all(
+      owners_hashes,
+      unique_by: [:email, :index_contract_owners_on_email],
+      returning: [:email, :id],
+      update_only: [:first_name, :last_name]
+    )
+  end
+
+  def upsert_contracts(owners, batch, session_id, updated_contracts_counter, invalid_contract_instances)
+    valid_contract_hashes = []
+    invalid_contract_instances = []
+    flash = {}
+
+    batch.each do |row|
+      time = Time.current
+      start_date = Date.strptime(row[HEADERS["Start Date"]], '%m/%d/%Y') unless row[HEADERS["Start Date"]].nil?
+      end_date = Date.strptime(row[HEADERS["End Date"]], '%m/%d/%Y') unless row[HEADERS["End Date"]].nil?
+      contract_hash = {
+        external_contract_id: row[HEADERS["External Contract ID"]],
+        name: row[HEADERS["Contract Name"]],
+        start_date: start_date,
+        end_date: end_date,
+        value_cents: row[HEADERS["Contract Value"]].try(:gsub, /\D/, '').try(:to_i),
+        supplier: row[HEADERS["Supplier"]],
+        updated_at: time,
+        created_at: time,
+        contract_owner_id: owners.rows.to_h[row[HEADERS["Contract Owner"]]]
+      }
+      contract_instance = initialize_to_validate(contract_hash)
+      unless contract_instance.valid?
+        invalid_contract_instances << contract_instance #an arror string should be pushd instead of the instance to a passed argument
+        flash[:alert] = {invalid_records: invalid_contract_instances}
+        Turbo::StreamsChannel.broadcast_replace_to("flash_#{session_id}", target: "flash", html: rendered_flash_component(flash:)
+      else
+        valid_contract_hashes << contract_hash
+      end
+    end
+
+    result = Contract.upsert_all(
+      valid_contract_hashes,
+      unique_by: [:external_contract_id, :index_contracts_on_external_contract_id],
+      returning: [:name, :start_date, :end_date, :value_cents, :supplier, :contract_owner_id]
+    )
+    updated_contracts_counter += result.length
+
+    if updated_contracts_counter > 0
+      flash[:notice] = "#{updated_contracts_counter} records have been created or updated successfuly"
+      Turbo::StreamsChannel.broadcast_replace_to("csv_import_#{@session_id}", target: "contracts", html: rendered_contract_row_component)
+    else
+      flash[:notice] = "No contracts have been updated or created"
+    end
+    Turbo::StreamsChannel.broadcast_replace_to("flash_#{@session_id}", target: "flash", html: rendered_flash_component(flash:))
+
+    { counter: updated_contracts_counter, invalid: invalid_countract_instances }
+  end
+
+  def initialize_to_validate(hash)
+    contract = Contract.find_or_initialize_by(external_contract_id: hash[:external_contract_id])
+    contract.assign_attributes(hash)
+    contract
+  end
+
+  def rendered_flash_component(flash: {})
+    ApplicationController.render(
+      FlashComponent.new(notice: @flash[:notice], alert: @flash[:alert]), layout: false
+    )
+  end
+
+  def rendered_contract_row_component
+    ApplicationController.render(
+      ContractRowComponent.with_collection(Contract.includes(:contract_owner)), layout: false
+    )
   end
 end

--- a/app/jobs/csv_contract_import_job.rb
+++ b/app/jobs/csv_contract_import_job.rb
@@ -14,7 +14,7 @@ class CsvContractImportJob < ApplicationJob
 
   def perform(csv_array:, session_id:, updated_contracts_counter: 0, validation_errors: {})
     if csv_array.length > 0
-      batch = csv_array.shift(3)
+      batch = csv_array.shift(500)
       emails = get_unique_emails(batch)
       owners = create_and_return_owners(emails)
       recursive_values = upsert_contracts(owners, batch, session_id, updated_contracts_counter, validation_errors)

--- a/app/jobs/csv_contract_import_job.rb
+++ b/app/jobs/csv_contract_import_job.rb
@@ -12,12 +12,28 @@ class CsvContractImportJob < ApplicationJob
     "Supplier" => 6
   }
 
-  def perform(csv_array:, session_id:, updated_contracts_counter: 0, invalid_contract_instances: {})
-    batch = csv_array.shift(500)
-    emails = get_unique_emails(batch)
-    owners = create_and_return_owners(emails)
-    recursive_values = upsert_contracts(owners, batch, session_id, updated_contracts_counter, invalid_contract_instances)
-    perform(csv_array:, session_id:, updated_contracts_counter: recursive_values[:counter], invalid_contract_instances: recursive_values[:invalid])
+  def perform(csv_array:, session_id:, updated_contracts_counter: 0, validation_errors: {})
+    if csv_array.length > 0
+      batch = csv_array.shift(3)
+      emails = get_unique_emails(batch)
+      owners = create_and_return_owners(emails)
+      recursive_values = upsert_contracts(owners, batch, session_id, updated_contracts_counter, validation_errors)
+      if csv_array.length > 0
+        perform(csv_array:, session_id:, updated_contracts_counter: recursive_values[:counter], validation_errors: recursive_values[:invalid])
+      end
+      #DEBUG TODO: something's happening with flash messages: they don't persist on every batch, but replace each batch of flashes
+      # successfuly updated contract counter doesn't add up either
+      if recursive_values[:counter] > 0
+        recursive_values[:flash][:notice] = "#{recursive_values[:counter]} records have been created or updated successfuly"
+        Turbo::StreamsChannel.broadcast_replace_to("csv_import_#{session_id}", target: "contracts", html: rendered_contract_row_component)
+      else
+        recursive_values[:flash][:notice] = "No contracts have been updated or created"
+      end
+      Turbo::StreamsChannel.broadcast_replace_to("flash_#{session_id}", target: "flash", html: rendered_flash_component(flash: recursive_values[:flash]))
+    else
+      flash = {alert: "Your csv file must be empty!"}
+      Turbo::StreamsChannel.broadcast_replace_to("flash_#{session_id}", target: "flash", html: rendered_flash_component(flash:))
+    end
   end
 
   private
@@ -44,9 +60,9 @@ class CsvContractImportJob < ApplicationJob
     )
   end
 
-  def upsert_contracts(owners, batch, session_id, updated_contracts_counter, invalid_contract_instances)
+  def upsert_contracts(owners, batch, session_id, updated_contracts_counter, validation_errors)
     valid_contract_hashes = []
-    invalid_contract_instances = []
+    validation_errors = {}
     flash = {}
 
     batch.each do |row|
@@ -66,30 +82,24 @@ class CsvContractImportJob < ApplicationJob
       }
       contract_instance = initialize_to_validate(contract_hash)
       unless contract_instance.valid?
-        invalid_contract_instances << contract_instance #an arror string should be pushd instead of the instance to a passed argument
-        flash[:alert] = {invalid_records: invalid_contract_instances}
-        Turbo::StreamsChannel.broadcast_replace_to("flash_#{session_id}", target: "flash", html: rendered_flash_component(flash:)
+        validation_errors[contract_instance.external_contract_id] = contract_instance.errors.full_messages
+        flash[:alert] = {invalid_records: validation_errors}
+        Turbo::StreamsChannel.broadcast_replace_to("flash_#{session_id}", target: "flash", html: rendered_flash_component(flash:))
       else
         valid_contract_hashes << contract_hash
       end
     end
 
-    result = Contract.upsert_all(
-      valid_contract_hashes,
-      unique_by: [:external_contract_id, :index_contracts_on_external_contract_id],
-      returning: [:name, :start_date, :end_date, :value_cents, :supplier, :contract_owner_id]
-    )
-    updated_contracts_counter += result.length
-
-    if updated_contracts_counter > 0
-      flash[:notice] = "#{updated_contracts_counter} records have been created or updated successfuly"
-      Turbo::StreamsChannel.broadcast_replace_to("csv_import_#{@session_id}", target: "contracts", html: rendered_contract_row_component)
-    else
-      flash[:notice] = "No contracts have been updated or created"
+    if valid_contract_hashes.length > 0
+      result = Contract.upsert_all(
+        valid_contract_hashes,
+        unique_by: [:external_contract_id, :index_contracts_on_external_contract_id],
+        returning: [:name, :start_date, :end_date, :value_cents, :supplier, :contract_owner_id]
+      )
+      updated_contracts_counter += result.length
     end
-    Turbo::StreamsChannel.broadcast_replace_to("flash_#{@session_id}", target: "flash", html: rendered_flash_component(flash:))
 
-    { counter: updated_contracts_counter, invalid: invalid_countract_instances }
+    { counter: updated_contracts_counter, invalid: validation_errors, flash: }
   end
 
   def initialize_to_validate(hash)
@@ -100,7 +110,7 @@ class CsvContractImportJob < ApplicationJob
 
   def rendered_flash_component(flash: {})
     ApplicationController.render(
-      FlashComponent.new(notice: @flash[:notice], alert: @flash[:alert]), layout: false
+      FlashComponent.new(notice: flash[:notice], alert: flash[:alert]), layout: false
     )
   end
 

--- a/app/services/csv_contract_import_service.rb
+++ b/app/services/csv_contract_import_service.rb
@@ -39,6 +39,7 @@ class CsvContractImportService
       # ContractImportJob.perform should be called on this line inside itself with sliced batch, or the next slice -- figure it out
     end
     
+    # the code block below would go to the end of #upsert_contracts method
     if @updated_contracts_counter > 0
       @flash[:notice] = "#{@updated_contracts_counter} records have been created or updated successfuly"
       Turbo::StreamsChannel.broadcast_replace_to("csv_import_#{@session_id}", target: "contracts", html: rendered_contract_row_component)

--- a/app/services/csv_contract_import_service.rb
+++ b/app/services/csv_contract_import_service.rb
@@ -1,37 +1,33 @@
 class CsvContractImportService
   require 'csv'
-  HEADERS = {
-    "Contract Owner" => 0,
-    "External Contract ID" => 1,
-    "Contract Name" => 2,
-    "Start Date" => 3,
-    "End Date" => 4,
-    "Contract Value" => 5,
-    "Supplier" => 6
-  }
+  # HEADERS = {
+  #   "Contract Owner" => 0,
+  #   "External Contract ID" => 1,
+  #   "Contract Name" => 2,
+  #   "Start Date" => 3,
+  #   "End Date" => 4,
+  #   "Contract Value" => 5,
+  #   "Supplier" => 6
+  # }
 
-  attr_reader :invalid_contract_instances, :updated_contracts_counter, :result_batches
-  def initialize(csv_array, session_id)
-    csv_array.shift
-    @csv_array = csv_array
-    @updated_contracts_counter = 0
-    @invalid_contract_instances = []
-    @result_batches = []
+  # attr_reader :invalid_contract_instances, :updated_contracts_counter, :result_batches
+  def initialize(file, session_id)
+    # csv_array.shift
+    # @csv_array = csv_array
+    # @updated_contracts_counter = 0
+    # @invalid_contract_instances = []
+    # @result_batches = []
+    @file = file
     @session_id = session_id
-    @flash = {}
+    # @flash = {}
   end
 
   def call
     # the method below should be implemented in this service:
-    #  def csv_file_to_a
-    #   require 'csv'
-    #   file = File.open(params[:file])
-    #   table = CSV.parse(file, headers: true)
-    #   table.to_a
-    # end
     # ContractImportJob should take batch_array,
     # session_id and updated_contracts_counter (add to arg every time),
     # invalid_contract_instances array of error strings, updated on every job
+    CsvContractImportJob.perform_later(csv_array:, session_id: @session_id)
     @csv_array.each_slice(500) do |batch| # these batches have to be performed as a background job
       emails = get_unique_emails(batch)
       owners = create_and_return_owners(emails)
@@ -50,82 +46,88 @@ class CsvContractImportService
   end
   
   private
-  
-  def get_unique_emails(batch)
-    batch.map {|row| row[HEADERS["Contract Owner"]]}.compact.uniq
+
+   def csv_array
+    file = File.open(@file)
+    table = CSV.parse(file, headers: true)
+    table.to_a
   end
   
-  def create_and_return_owners(emails)
-    owners_hashes = emails.map do |email|
-      split_email = email.split(/\.|@/)
-      {
-        first_name: split_email[0].capitalize,
-        last_name: split_email[1].capitalize,
-        email: email
-      }
-    end
-
-    ContractOwner.upsert_all(
-      owners_hashes,
-      unique_by: [:email, :index_contract_owners_on_email],
-      returning: [:email, :id],
-      update_only: [:first_name, :last_name]
-    )
-  end
+  # def get_unique_emails(batch)
+  #   batch.map {|row| row[HEADERS["Contract Owner"]]}.compact.uniq
+  # end
   
-  def upsert_contracts(owners, batch)
-    valid_contract_hashes = []
+  # def create_and_return_owners(emails)
+  #   owners_hashes = emails.map do |email|
+  #     split_email = email.split(/\.|@/)
+  #     {
+  #       first_name: split_email[0].capitalize,
+  #       last_name: split_email[1].capitalize,
+  #       email: email
+  #     }
+  #   end
 
-    batch.each do |row|
-      time = Time.current
-      start_date = Date.strptime(row[HEADERS["Start Date"]], '%m/%d/%Y') unless row[HEADERS["Start Date"]].nil?
-      end_date = Date.strptime(row[HEADERS["End Date"]], '%m/%d/%Y') unless row[HEADERS["End Date"]].nil?
-      contract_hash = {
-        external_contract_id: row[HEADERS["External Contract ID"]],
-        name: row[HEADERS["Contract Name"]],
-        start_date: start_date,
-        end_date: end_date,
-        value_cents: row[HEADERS["Contract Value"]].try(:gsub, /\D/, '').try(:to_i),
-        supplier: row[HEADERS["Supplier"]],
-        updated_at: time,
-        created_at: time,
-        contract_owner_id: owners.rows.to_h[row[HEADERS["Contract Owner"]]]
-      }
-      contract_instance = initialize_to_validate(contract_hash)
+  #   ContractOwner.upsert_all(
+  #     owners_hashes,
+  #     unique_by: [:email, :index_contract_owners_on_email],
+  #     returning: [:email, :id],
+  #     update_only: [:first_name, :last_name]
+  #   )
+  # end
+  
+  # def upsert_contracts(owners, batch)
+  #   valid_contract_hashes = []
 
-      unless contract_instance.valid?
-        @invalid_contract_instances << contract_instance #an arror string should be pushd instead of the instance to a passed argument
-        @flash[:alert] = {invalid_records: @invalid_contract_instances}
-        Turbo::StreamsChannel.broadcast_replace_to("flash_#{@session_id}", target: "flash", html: rendered_flash_component)
-      else
-        valid_contract_hashes << contract_hash
-      end
-    end
+  #   batch.each do |row|
+  #     time = Time.current
+  #     start_date = Date.strptime(row[HEADERS["Start Date"]], '%m/%d/%Y') unless row[HEADERS["Start Date"]].nil?
+  #     end_date = Date.strptime(row[HEADERS["End Date"]], '%m/%d/%Y') unless row[HEADERS["End Date"]].nil?
+  #     contract_hash = {
+  #       external_contract_id: row[HEADERS["External Contract ID"]],
+  #       name: row[HEADERS["Contract Name"]],
+  #       start_date: start_date,
+  #       end_date: end_date,
+  #       value_cents: row[HEADERS["Contract Value"]].try(:gsub, /\D/, '').try(:to_i),
+  #       supplier: row[HEADERS["Supplier"]],
+  #       updated_at: time,
+  #       created_at: time,
+  #       contract_owner_id: owners.rows.to_h[row[HEADERS["Contract Owner"]]]
+  #     }
+  #     contract_instance = initialize_to_validate(contract_hash)
 
-    result = Contract.upsert_all(
-      valid_contract_hashes,
-      unique_by: [:external_contract_id, :index_contracts_on_external_contract_id],
-      returning: [:name, :start_date, :end_date, :value_cents, :supplier, :contract_owner_id]
-    )
-    @updated_contracts_counter += result.length
-    result
-  end
+  #     unless contract_instance.valid?
+  #       @invalid_contract_instances << contract_instance #an arror string should be pushd instead of the instance to a passed argument
+  #       @flash[:alert] = {invalid_records: @invalid_contract_instances}
+  #       Turbo::StreamsChannel.broadcast_replace_to("flash_#{@session_id}", target: "flash", html: rendered_flash_component)
+  #     else
+  #       valid_contract_hashes << contract_hash
+  #     end
+  #   end
 
-  def initialize_to_validate(hash)
-    contract = Contract.find_or_initialize_by(external_contract_id: hash[:external_contract_id])
-    contract.assign_attributes(hash)
-    contract
-  end
+  #   result = Contract.upsert_all(
+  #     valid_contract_hashes,
+  #     unique_by: [:external_contract_id, :index_contracts_on_external_contract_id],
+  #     returning: [:name, :start_date, :end_date, :value_cents, :supplier, :contract_owner_id]
+  #   )
+  #   @updated_contracts_counter += result.length
+  #   result
+  # end
 
-  def rendered_flash_component
-    ApplicationController.render(
-      FlashComponent.new(notice: @flash[:notice], alert: @flash[:alert]), layout: false
-    )
-  end
+  # def initialize_to_validate(hash)
+  #   contract = Contract.find_or_initialize_by(external_contract_id: hash[:external_contract_id])
+  #   contract.assign_attributes(hash)
+  #   contract
+  # end
 
-  def rendered_contract_row_component
-    ApplicationController.render(
-      ContractRowComponent.with_collection(Contract.includes(:contract_owner)), layout: false
-    )
-  end
+  # def rendered_flash_component
+  #   ApplicationController.render(
+  #     FlashComponent.new(notice: @flash[:notice], alert: @flash[:alert]), layout: false
+  #   )
+  # end
+
+  # def rendered_contract_row_component
+  #   ApplicationController.render(
+  #     ContractRowComponent.with_collection(Contract.includes(:contract_owner)), layout: false
+  #   )
+  # end
 end

--- a/app/services/csv_contract_import_service.rb
+++ b/app/services/csv_contract_import_service.rb
@@ -1,133 +1,19 @@
 class CsvContractImportService
   require 'csv'
-  # HEADERS = {
-  #   "Contract Owner" => 0,
-  #   "External Contract ID" => 1,
-  #   "Contract Name" => 2,
-  #   "Start Date" => 3,
-  #   "End Date" => 4,
-  #   "Contract Value" => 5,
-  #   "Supplier" => 6
-  # }
-
-  # attr_reader :invalid_contract_instances, :updated_contracts_counter, :result_batches
   def initialize(file, session_id)
-    # csv_array.shift
-    # @csv_array = csv_array
-    # @updated_contracts_counter = 0
-    # @invalid_contract_instances = []
-    # @result_batches = []
     @file = file
     @session_id = session_id
-    # @flash = {}
   end
 
   def call
-    # the method below should be implemented in this service:
-    # ContractImportJob should take batch_array,
-    # session_id and updated_contracts_counter (add to arg every time),
-    # invalid_contract_instances array of error strings, updated on every job
     CsvContractImportJob.perform_later(csv_array:, session_id: @session_id)
-    @csv_array.each_slice(500) do |batch| # these batches have to be performed as a background job
-      emails = get_unique_emails(batch)
-      owners = create_and_return_owners(emails)
-      @result_batches << upsert_contracts(owners, batch)
-      # ContractImportJob.perform should be called on this line inside itself with sliced batch, or the next slice -- figure it out
-    end
-    
-    # the code block below would go to the end of #upsert_contracts method
-    if @updated_contracts_counter > 0
-      @flash[:notice] = "#{@updated_contracts_counter} records have been created or updated successfuly"
-      Turbo::StreamsChannel.broadcast_replace_to("csv_import_#{@session_id}", target: "contracts", html: rendered_contract_row_component)
-    else
-      @flash[:notice] = "No contracts have been updated or created"
-    end
-    Turbo::StreamsChannel.broadcast_replace_to("flash_#{@session_id}", target: "flash", html: rendered_flash_component)
   end
   
   private
 
    def csv_array
     file = File.open(@file)
-    table = CSV.parse(file, headers: true)
-    table.to_a
+    table = CSV.parse(file)
+    table.to_a[1..]
   end
-  
-  # def get_unique_emails(batch)
-  #   batch.map {|row| row[HEADERS["Contract Owner"]]}.compact.uniq
-  # end
-  
-  # def create_and_return_owners(emails)
-  #   owners_hashes = emails.map do |email|
-  #     split_email = email.split(/\.|@/)
-  #     {
-  #       first_name: split_email[0].capitalize,
-  #       last_name: split_email[1].capitalize,
-  #       email: email
-  #     }
-  #   end
-
-  #   ContractOwner.upsert_all(
-  #     owners_hashes,
-  #     unique_by: [:email, :index_contract_owners_on_email],
-  #     returning: [:email, :id],
-  #     update_only: [:first_name, :last_name]
-  #   )
-  # end
-  
-  # def upsert_contracts(owners, batch)
-  #   valid_contract_hashes = []
-
-  #   batch.each do |row|
-  #     time = Time.current
-  #     start_date = Date.strptime(row[HEADERS["Start Date"]], '%m/%d/%Y') unless row[HEADERS["Start Date"]].nil?
-  #     end_date = Date.strptime(row[HEADERS["End Date"]], '%m/%d/%Y') unless row[HEADERS["End Date"]].nil?
-  #     contract_hash = {
-  #       external_contract_id: row[HEADERS["External Contract ID"]],
-  #       name: row[HEADERS["Contract Name"]],
-  #       start_date: start_date,
-  #       end_date: end_date,
-  #       value_cents: row[HEADERS["Contract Value"]].try(:gsub, /\D/, '').try(:to_i),
-  #       supplier: row[HEADERS["Supplier"]],
-  #       updated_at: time,
-  #       created_at: time,
-  #       contract_owner_id: owners.rows.to_h[row[HEADERS["Contract Owner"]]]
-  #     }
-  #     contract_instance = initialize_to_validate(contract_hash)
-
-  #     unless contract_instance.valid?
-  #       @invalid_contract_instances << contract_instance #an arror string should be pushd instead of the instance to a passed argument
-  #       @flash[:alert] = {invalid_records: @invalid_contract_instances}
-  #       Turbo::StreamsChannel.broadcast_replace_to("flash_#{@session_id}", target: "flash", html: rendered_flash_component)
-  #     else
-  #       valid_contract_hashes << contract_hash
-  #     end
-  #   end
-
-  #   result = Contract.upsert_all(
-  #     valid_contract_hashes,
-  #     unique_by: [:external_contract_id, :index_contracts_on_external_contract_id],
-  #     returning: [:name, :start_date, :end_date, :value_cents, :supplier, :contract_owner_id]
-  #   )
-  #   @updated_contracts_counter += result.length
-  #   result
-  # end
-
-  # def initialize_to_validate(hash)
-  #   contract = Contract.find_or_initialize_by(external_contract_id: hash[:external_contract_id])
-  #   contract.assign_attributes(hash)
-  #   contract
-  # end
-
-  # def rendered_flash_component
-  #   ApplicationController.render(
-  #     FlashComponent.new(notice: @flash[:notice], alert: @flash[:alert]), layout: false
-  #   )
-  # end
-
-  # def rendered_contract_row_component
-  #   ApplicationController.render(
-  #     ContractRowComponent.with_collection(Contract.includes(:contract_owner)), layout: false
-  #   )
-  # end
 end


### PR DESCRIPTION
Refactors the CSV import with recursive background job perform method call per array batch, slicing the batch out of the array on every recursion. It's done as an experiment to potentially reduce the wait time per single background job in case of a large data array.
Potential pitfalls: even though I've implemented safeguards, potential stack overflow in case of large amount of background jobs with still big arrays accumulating in memory (which is high probability).
TODO: fix tests; fix pagination update per contract stream